### PR TITLE
Make Travis use F28 base image for testing

### DIFF
--- a/fedora/Dockerfile
+++ b/fedora/Dockerfile
@@ -1,1 +1,1 @@
-Dockerfile.fedora27
+Dockerfile.fedora28

--- a/fedora/Dockerfile.fedora27
+++ b/fedora/Dockerfile.fedora27
@@ -13,7 +13,7 @@ RUN echo 'deltarpm = false' >> /etc/dnf/dnf.conf \
 
 # install build dependencies from COPR and latest devel branch
 RUN dnf install -y @buildsys-build @development-tools \
-    && wget https://raw.githubusercontent.com/freeipa/freeipa/master/freeipa.spec.in \
+    && wget https://raw.githubusercontent.com/freeipa/freeipa/ipa-4-6/freeipa.spec.in \
     && dnf builddep -y --spec ./freeipa.spec.in \
         -D "with_lint 1" -D "with_wheels 1" --best --allowerasing \
     && dnf clean all \


### PR DESCRIPTION
This makes the F28 container to appear under the `master-latest` tag on dockerhub.

Depends on: https://github.com/freeipa/freeipa/pull/1785