### PR TITLE
Fix ipa-4-7 Fedora 28 build

### DIFF
--- a/fedora/Dockerfile.fedora28
+++ b/fedora/Dockerfile.fedora28
@@ -6,6 +6,8 @@ RUN echo 'deltarpm = false' >> /etc/dnf/dnf.conf \
     && dnf install -y dnf-plugins-core sudo wget \
     && dnf config-manager --set-enabled updates-testing \
     && dnf copr enable -y @freeipa/freeipa-4-7 \
+    # Enable @pki/master because https://github.com/freeipa/freeipa/commit/4683c6b2efb83da0765b74c12b2795c04b620b36
+    && dnf copr enable -y @pki/master \
     # FIXME: due to packaging issues the following is not a dependency of
     # python{2,3}-rpm-macros, and must be installed manually
     && dnf install -y python-srpm-macros \
@@ -13,7 +15,7 @@ RUN echo 'deltarpm = false' >> /etc/dnf/dnf.conf \
 
 # install build dependencies from COPR and latest devel branch
 RUN dnf install -y @buildsys-build @development-tools \
-    && wget https://raw.githubusercontent.com/freeipa/freeipa/master/freeipa.spec.in \
+    && wget https://raw.githubusercontent.com/freeipa/freeipa/ipa-4-7/freeipa.spec.in \
     && dnf builddep -y --spec ./freeipa.spec.in \
         -D "with_lint 1" -D "with_wheels 1" --best --allowerasing \
     && dnf clean all \


### PR DESCRIPTION
Replace spec file used and Enable @pki/master copr.

Signed-off-by: Armando Neto <abiagion@redhat.com>